### PR TITLE
fix(cljs): treat cljs.core/await (cljs >= 1.12) as a CPS breakpoint

### DIFF
--- a/src/is/simm/partial_cps/async.cljc
+++ b/src/is/simm/partial_cps/async.cljc
@@ -78,7 +78,15 @@
          (~(first args) safe-r# ~e)))))
 
 (def ^:no-doc breakpoints
-  {`await `await-handler})
+  {`await `await-handler
+   ;; ClojureScript >= 1.12 added a core `await` MACRO (native JS async/await interop).
+   ;; It is auto-referred into every ns and, being a macro, wins over a `:refer`'d
+   ;; partial-cps `await` in call position. We register it as the SAME CPS breakpoint so
+   ;; that inside a partial-cps `async`, a bare `(await x)` is CPS-transformed whether it
+   ;; resolves to partial-cps's `await` or `cljs.core/await` — no per-ns
+   ;; `(:refer-clojure :exclude [await])` needed. (On the JVM `cljs.core/await` never
+   ;; resolves, so this key is simply inert there.)
+   'cljs.core/await `await-handler})
 
 #?(:clj
    (defmacro async

--- a/src/is/simm/partial_cps/ioc.clj
+++ b/src/is/simm/partial_cps/ioc.clj
@@ -17,8 +17,11 @@
     ;; Don't qualify special forms or core symbols that shouldn't be qualified
     (when-not (special-symbol? sym)
       (if (:js-globals env)
-        ;; In Clojurescript use cljs.analyzer
-        (:name (resolve-var-cljs env sym))
+        ;; In ClojureScript use cljs.analyzer — resolve as a var, FALLING BACK to a
+        ;; macro var so a macro-named breakpoint (e.g. `cljs.core/await` on cljs >= 1.12)
+        ;; resolves to its fully-qualified name and can be matched in `breakpoints`.
+        (or (:name (resolve-var-cljs env sym))
+            (:name (resolve-macro-var-cljs env sym)))
         ;; In Clojure — use str instead of .getName for SCI namespace compatibility
         (when-let [v (resolve env sym)]
           (let [m (meta v)
@@ -52,7 +55,13 @@
   (let [cache-key (when breakpoint-cache [form (some? recur-target)])]
     (if-let [cached-result (when cache-key (get @breakpoint-cache cache-key))]
       cached-result
-      (let [[form-to-check ctx'] (if-let [cached (when expansion-cache (get @expansion-cache form))]
+      ;; A registered breakpoint is TERMINAL: match it on the ORIGINAL operator WITHOUT
+      ;; macroexpanding, so a breakpoint that is ALSO a macro (e.g. `cljs.core/await` on
+      ;; cljs >= 1.12) is never expanded (its expansion would fire the macro's own assert).
+      (if (and (seq? form) (symbol? (first form))
+               (contains? breakpoints (var-name env (first form))))
+        (do (when cache-key (swap! breakpoint-cache assoc cache-key true)) true)
+        (let [[form-to-check ctx'] (if-let [cached (when expansion-cache (get @expansion-cache form))]
                                    [cached ctx]
                                     ;; Not in cache, try to expand
                                    (if-let [[expanded _] (expand-macro form env)]
@@ -83,7 +92,7 @@
         ;; Cache the result for this form
         (when cache-key
           (swap! breakpoint-cache assoc cache-key (boolean result)))
-        result))))
+        result)))))
 
 (defn can-inline?
   [form]
@@ -206,16 +215,19 @@
                           (nil? head-ns))))))
       (handle-binding-form ctx form)
 
-      ;; Check if this is a macro and expand it
-      (if (and head (symbol? head) (:js-globals env))
-        ;; use cljs.analyzer to find macro var info — guard symbol? first:
-        ;; `resolve-macro-var-cljs` casts head to Symbol, so a keyword-fn head
-        ;; like `(:k (await x))` would otherwise throw ClassCastException on cljs
-        ;; (the CLJ branch below already guards `symbol?`).
-        (:macro (resolve-macro-var-cljs env head))
-        ;; use normal Clojure resolve — meta check for SCI compatibility
-        (let [resolved (when (symbol? head) (resolve env head))]
-          (and resolved (:macro (meta resolved)))))
+      ;; Check if this is a macro and expand it — UNLESS it is a registered breakpoint.
+      ;; A breakpoint that is ALSO a macro (e.g. `cljs.core/await` on cljs >= 1.12) must be
+      ;; dispatched to its handler (the breakpoint clause below), NOT macroexpanded.
+      (and (not (and (symbol? head) (contains? breakpoints (var-name env head))))
+           (if (and head (symbol? head) (:js-globals env))
+             ;; use cljs.analyzer to find macro var info — guard symbol? first:
+             ;; `resolve-macro-var-cljs` casts head to Symbol, so a keyword-fn head
+             ;; like `(:k (await x))` would otherwise throw ClassCastException on cljs
+             ;; (the CLJ branch below already guards `symbol?`).
+             (:macro (resolve-macro-var-cljs env head))
+             ;; use normal Clojure resolve — meta check for SCI compatibility
+             (let [resolved (when (symbol? head) (resolve env head))]
+               (and resolved (:macro (meta resolved))))))
       (recur ctx
              (apply (if (:js-globals env)
                       (resolve (:name (resolve-macro-var-cljs env head)))


### PR DESCRIPTION
## Problem

ClojureScript 1.12 added a core `await` **macro** (native JS async/await interop):

```clojure
(core/defmacro await [expr]
  (core/assert (:async &env) "await can only be used in async contexts")
  (core/list 'js* "(await ~{})" expr))
```

It is auto-referred into every namespace and, being a macro, **wins over a `:refer`'d partial-cps `await` in call position**. So any cljs/cljc namespace that uses partial-cps `await` (without `(:refer-clojure :exclude [await])`) broke under cljs ≥ 1.12: the IoC transform tried to macroexpand `cljs.core/await`, whose `(:async &env)` assertion fails inside a partial-cps `async` block — surfacing first in `persistent-sorted-set`'s `btset.cljs` and cascading to every downstream cljs consumer.

## Fix

Fix it **centrally** instead of forcing every consumer (PSS, yggdrasil, spindel, …) to exclude the core var forever. The principle: **a registered breakpoint is terminal — it must never be macroexpanded, even when it is also a macro.**

- `async`: register `cljs.core/await` in `breakpoints` → the same `await-handler`.
- `ioc/var-name`: on cljs, fall back to `resolve-macro-var` so a macro-named breakpoint resolves to its qualified name (it has no runtime var, so `resolve-var` alone can't see it).
- `ioc/has-breakpoints?`: short-circuit on the **original** operator *before* macroexpanding, so a breakpoint-macro is recognized and not expanded (its expansion would fire the macro's own assert).
- `ioc/invert-impl`: skip the macro-expansion branch for a registered breakpoint; let it fall through to the breakpoint-handler dispatch.

Now `(await x)` inside `(async …)` CPS-transforms whether `await` resolves to partial-cps's `await` or `cljs.core/await`. **No per-ns `(:refer-clojure :exclude [await])` needed anywhere.** Behaviour outside a partial-cps `async` is unchanged (real JS `^:async`/`await` interop still works); on the JVM the `cljs.core/await` key is simply inert.

## Verification

- **JVM**: `clojure -M:test` → 150 tests / 198 assertions, 0 failures (no regression on the clj path).
- **cljs 1.12.42 smoke** (`test/.../cljs_await_smoke.cljs`, a ns that `:refer`s `await` *without* excluding the core macro): compiled + run under `cljs.main` node → prints `PASS … 84` instead of the assert error.
- **End-to-end**: a downstream konserve-backed shadow build (shadow-cljs 3.4.11, cljs 1.12, this branch as `:local/root`) **compiles** — PSS's `btset.cljs` `await` now compiles — and runs the durable-CRDT cljs tests with no await errors / no assertion failures.

The smoke is a manual `-main`; a follow-up should bump the project's cljs test toolchain to ≥ 1.12 (shadow-cljs 3.x) so the suite guards this automatically.
