### PR TITLE
feat: optional core.async ↔ partial-cps adapter

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -22,7 +22,7 @@
                   :lib lib
                   :version v
                   :basis @basis
-                  :src-dirs ["src"]
+                  :src-dirs ["src" "src-core-async"]
                   :scm {:url "https://github.com/simm-is/partial-cps"
                         :connection "scm:git:git://github.com/simm-is/partial-cps.git"
                         :developerConnection "scm:git:ssh://git@github.com/simm-is/partial-cps.git"
@@ -33,7 +33,7 @@
                               [:license
                                [:name "Eclipse Public License"]
                                [:url "http://www.eclipse.org/legal/epl-v10.html"]]]]})
-    (b/copy-dir {:src-dirs ["src" "resources"]
+    (b/copy-dir {:src-dirs ["src" "src-core-async" "resources"]
                  :target-dir class-dir})
     (b/jar {:class-dir class-dir
             :jar-file jf})

--- a/deps.edn
+++ b/deps.edn
@@ -1,22 +1,32 @@
-{:paths ["src" "resources"]
+;; `src-core-async` carries the OPTIONAL core.async↔partial-cps adapter
+;; (is.simm.partial-cps.core-async). It is on :paths (so it ships in the jar and
+;; :local/root consumers see it) but core.async is NOT a base :dep — the ns only
+;; loads for code that already pulls core.async (provided dep). Test/bench it via
+;; the :core-async alias, which adds core.async.
+{:paths ["src" "src-core-async" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}}
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                  slipset/deps-deploy {:mvn/version "0.2.2"}}
           :ns-default build}
 
+  ;; core.async present → lets partial-cps compile/test the optional adapter ns.
+  :core-async {:extra-deps {org.clojure/core.async {:mvn/version "1.6.681"}}}
+
   :test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
+                      ;; the adapter's own tests need core.async (optional dep)
+                      org.clojure/core.async {:mvn/version "1.6.681"}
                       io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]
          :exec-fn cognitect.test-runner.api/test}
 
   :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}
-           :main-opts ["-m" "cljfmt.main" "check" "src" "test"]}
+           :main-opts ["-m" "cljfmt.main" "check" "src" "src-core-async" "test"]}
 
   :ffix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}
-         :main-opts ["-m" "cljfmt.main" "fix" "src" "test"]}
+         :main-opts ["-m" "cljfmt.main" "fix" "src" "src-core-async" "test"]}
 
   :bench {:extra-paths ["test"]
           :extra-deps {criterium/criterium {:mvn/version "0.4.6"}}}}}

--- a/src-core-async/is/simm/partial_cps/core_async.cljc
+++ b/src-core-async/is/simm/partial_cps/core_async.cljc
@@ -1,0 +1,117 @@
+(ns is.simm.partial-cps.core-async
+  "OPTIONAL core.async ↔ partial-cps adapter — the two-way bridge between
+   `clojure.core.async` channels and partial-cps CPS values, so the two substrates
+   compose without either side hard-depending on the other.
+
+   core.async is NOT a base partial-cps dependency: this namespace lives on its own
+   source path (`src-core-async`, shipped in the jar) and is only loaded by code that
+   already pulls core.async. Require it from such code; base partial-cps users never
+   touch it.
+
+   Two directions — both NON-blocking (this adapter never `<!!`s; deciding to block is
+   the caller's concern, not the bridge's):
+     - `->cps` / `chan->cps` — a core.async channel (or value, or CPS) → a partial-cps
+       CPS `(fn [resolve raise])`, so it is `await`-able inside a partial-cps `async`.
+     - `->chan` — a CPS (or value, or channel) → a core.async channel, so it is `<!`-able
+       inside a `go` block. `unwrap-result` restores the datum (re-throws an error,
+       nil for the sentinel).
+     - `sync-or-cps` — bridge a `:sync?`-aware result (value on sync / channel on async)
+       into an `async+sync` body, NON-blocking either way.
+
+   Error convention: an error is a Throwable / JS error delivered ON the channel (so
+   `unwrap-result` re-throws it) or passed to a CPS `raise`. A genuine nil datum is
+   carried as `sentinel-nil` (core.async forbids nil puts)."
+  (:require #?(:clj  [clojure.core.async :refer [chan put! close! take!]]
+               :cljs [cljs.core.async :refer [chan put! close! take!]])
+            #?(:clj  [clojure.core.async.impl.protocols :as impl]
+               :cljs [cljs.core.async.impl.protocols :as impl])))
+
+(defn chan?
+  "True if x is a core.async channel. (core.async 1.6.681 ships no public `chan?`,
+   so we test the ReadPort impl protocol; a one-liner swap when core.async is bumped.)"
+  [x]
+  (and (some? x) (satisfies? impl/ReadPort x)))
+
+(defn error? [v]
+  (instance? #?(:clj Throwable :cljs js/Error) v))
+
+(defn rewrap
+  "Re-wrap an error VALUE in a FRESH `ex-info` — message + ex-data preserved, the
+   original as `cause`. This is superv.async's `throw-if-exception` convention: when
+   an error that was caught + carried as a channel/CPS value is re-thrown in another
+   context, the wrapper adds the boundary's stack frame while the cause chain keeps
+   the original, so a core.async error propagates into partial-cps (and back) with a
+   full trace. Unlike superv there is NO supervisor coupling (no `-free-exception`),
+   so this works for plain core.async too — the shared convention is just
+   `error-as-a-value-on-the-channel`."
+  [e]
+  (ex-info (or #?(:clj (.getMessage ^Throwable e) :cljs (.-message e)) (str e))
+           (or (ex-data e) {})
+           e))
+
+(def sentinel-nil
+  "Stand-in for a genuine nil datum (core.async forbids nil puts)."
+  ::nil)
+
+;; ── direction 1: core.async channel → partial-cps CPS (await-able) ──────────
+
+(defn chan->cps
+  "Wrap a core.async channel as a partial-cps CPS fn `(fn [resolve raise])`:
+   `take!` the channel, `raise` on a Throwable/JS-error value, else `resolve`."
+  [ch]
+  (fn [resolve raise]
+    (take! ch (fn [v] (if (error? v) (raise (rewrap v)) (resolve v))))))
+
+(defn ->cps
+  "Normalize value | core.async channel | CPS fn into a partial-cps CPS fn
+   (`await`-able). A plain value resolves immediately; a CPS passes through."
+  [x]
+  (cond
+    (chan? x) (chan->cps x)
+    (fn? x)   x
+    :else     (fn [resolve _raise] (resolve x))))
+
+;; ── direction 2: partial-cps CPS (or value/chan) → core.async channel ───────
+
+(defn- put-datum! [ch v]
+  (put! ch (if (nil? v) sentinel-nil v))
+  (close! ch))
+
+(defn ->chan
+  "Normalize value | core.async channel | partial-cps CPS `(fn [resolve raise])`
+   into a core.async channel delivering the resolved datum (genuine nil as
+   `sentinel-nil`; an error as a Throwable/JS error on the channel). Read with
+   `(unwrap-result (<! (->chan x)))`.
+
+   Invoking a partial-cps CPS directly from a core.async go-block is safe with no
+   trampoline rebind — the `async` fn self-establishes its trampoline."
+  [x]
+  (cond
+    (chan? x) x
+    (fn? x)   (let [c (chan 1)]
+                (try
+                  (x (fn [v] (put-datum! c v))
+                     (fn [e] (put! c e) (close! c)))
+                  (catch #?(:clj Throwable :cljs :default) e
+                    (put! c e) (close! c)))
+                c)
+    :else     (let [c (chan 1)] (put-datum! c x) c)))
+
+(defn unwrap-result
+  "Restore a datum read off a `->chan` channel: re-throw on error, nil for the
+   sentinel, else the value."
+  [v]
+  (cond
+    (error? v)         (throw (rewrap v))
+    (= v sentinel-nil) nil
+    :else              v))
+
+(defn sync-or-cps
+  "Bridge a `:sync?`-aware result (a VALUE on `{:sync? true}`, a core.async CHANNEL
+   on `{:sync? false}`) into an `async+sync` body — NON-blocking either way: pass the
+   already-materialized value through on sync, else wrap the channel as an await-able
+   CPS. (For a source that has NO sync mode — always a channel — there is no
+   non-blocking sync option; that block belongs at the caller that knows the source,
+   not in this generic adapter.)"
+  [result opts]
+  (if (:sync? opts) result (chan->cps result)))

--- a/src/is/simm/partial_cps/ioc.clj
+++ b/src/is/simm/partial_cps/ioc.clj
@@ -62,37 +62,37 @@
                (contains? breakpoints (var-name env (first form))))
         (do (when cache-key (swap! breakpoint-cache assoc cache-key true)) true)
         (let [[form-to-check ctx'] (if-let [cached (when expansion-cache (get @expansion-cache form))]
-                                   [cached ctx]
+                                     [cached ctx]
                                     ;; Not in cache, try to expand
-                                   (if-let [[expanded _] (expand-macro form env)]
-                                     (do
-                                       (when expansion-cache
-                                         (swap! expansion-cache assoc form expanded))
+                                     (if-let [[expanded _] (expand-macro form env)]
+                                       (do
+                                         (when expansion-cache
+                                           (swap! expansion-cache assoc form expanded))
                                         ;; Recursively check the expansion
-                                       [expanded ctx])
+                                         [expanded ctx])
                                       ;; Not a macro, use form as-is
-                                     [form ctx]))
-            sym (when (seq? form-to-check) (first form-to-check))
-            resolved-sym (var-name env sym)
-            has-term? (contains? breakpoints resolved-sym)
-            result (cond
-                     has-term? true
+                                       [form ctx]))
+              sym (when (seq? form-to-check) (first form-to-check))
+              resolved-sym (var-name env sym)
+              has-term? (contains? breakpoints resolved-sym)
+              result (cond
+                       has-term? true
 
-                     (and recur-target (= 'recur sym)) true
+                       (and recur-target (= 'recur sym)) true
 
                      ;; If we just expanded this form and it's different, recurse to check the expansion
-                     (and (not= form form-to-check) (not has-term?))
-                     (has-breakpoints? form-to-check ctx')
+                       (and (not= form form-to-check) (not has-term?))
+                       (has-breakpoints? form-to-check ctx')
 
-                     (= 'loop* sym) (some #(has-breakpoints? % (dissoc ctx' :recur-target)) (rest form-to-check))
+                       (= 'loop* sym) (some #(has-breakpoints? % (dissoc ctx' :recur-target)) (rest form-to-check))
 
-                     (coll? form-to-check) (some #(has-breakpoints? % ctx') form-to-check)
+                       (coll? form-to-check) (some #(has-breakpoints? % ctx') form-to-check)
 
-                     :else false)]
+                       :else false)]
         ;; Cache the result for this form
-        (when cache-key
-          (swap! breakpoint-cache assoc cache-key (boolean result)))
-        result)))))
+          (when cache-key
+            (swap! breakpoint-cache assoc cache-key (boolean result)))
+          result)))))
 
 (defn can-inline?
   [form]

--- a/test/is/simm/partial_cps/core_async_test.clj
+++ b/test/is/simm/partial_cps/core_async_test.clj
@@ -1,0 +1,77 @@
+(ns is.simm.partial-cps.core-async-test
+  "Unit coverage for the optional core.async↔partial-cps adapter. Run under the
+   :test (or :core-async) alias, which provides core.async. The cljs side is
+   exercised downstream (yggdrasil + spindel suites + the cross-runtime e2es)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [is.simm.partial-cps.core-async :as ca]
+            [is.simm.partial-cps.async :refer [async await]]
+            [clojure.core.async :refer [chan put! close! <!!]]))
+
+(defn- closed-chan [v]
+  (let [c (chan 1)] (when (some? v) (put! c v)) (close! c) c))
+
+(deftest ->chan-normalizes-the-three-shapes
+  (testing "plain value (incl. nil) → channel yielding the datum"
+    (is (= 42 (ca/unwrap-result (<!! (ca/->chan 42)))))
+    (is (nil? (ca/unwrap-result (<!! (ca/->chan nil)))) "genuine nil survives the sentinel"))
+  (testing "core.async channel → passed through"
+    (is (= 7 (ca/unwrap-result (<!! (ca/->chan (closed-chan 7)))))))
+  (testing "partial-cps CPS fn → invoked, datum delivered"
+    (is (= 99 (ca/unwrap-result (<!! (ca/->chan (fn [resolve _] (resolve 99)))))))
+    (is (nil? (ca/unwrap-result (<!! (ca/->chan (fn [resolve _] (resolve nil)))))))))
+
+(deftest ->chan-carries-errors
+  (testing "a CPS raise delivers the error so unwrap-result re-throws"
+    (is (thrown-with-msg? Exception #"boom"
+                          (ca/unwrap-result (<!! (ca/->chan (fn [_ raise] (raise (ex-info "boom" {})))))))))
+  (testing "a CPS that throws synchronously is caught + re-thrown"
+    (is (thrown-with-msg? Exception #"sync-throw"
+                          (ca/unwrap-result (<!! (ca/->chan (fn [_ _] (throw (ex-info "sync-throw" {}))))))))))
+
+(deftest rewrap-preserves-message-ex-data-and-cause
+  (testing "the superv.async boundary convention: re-throw wraps in a fresh ex-info
+            with the original message + ex-data, and the original as cause"
+    (let [orig    (ex-info "original" {:code 42})
+          thrown  (try (ca/unwrap-result (<!! (ca/->chan (fn [_ raise] (raise orig)))))
+                       (catch clojure.lang.ExceptionInfo e e))]
+      (is (= "original" (.getMessage thrown)) "message preserved")
+      (is (= {:code 42} (ex-data thrown)) "ex-data preserved")
+      (is (identical? orig (.getCause thrown)) "original kept as cause (full trace)"))))
+
+(deftest ->cps-and-await-roundtrip
+  (testing "->cps makes value/chan/cps await-able inside a partial-cps async block"
+    (is (= [42 7 99]
+           (<!! (ca/->chan
+                 (async
+                  [(await (ca/->cps 42))
+                   (await (ca/->cps (closed-chan 7)))
+                   (await (ca/->cps (fn [resolve _] (resolve 99))))])))))))
+
+(deftest channel-error-propagates-into-partial-cps-error-path
+  (testing "an error VALUE taken off a channel surfaces via partial-cps's RAISE
+            (the error continuation), not resolve — awaiting it inside an `async`
+            block routes to the block's error path, so unwrap-result re-throws it"
+    (is (thrown-with-msg? Exception #"chan-err"
+                          (ca/unwrap-result
+                           (<!! (ca/->chan
+                                 (async (await (ca/->cps (closed-chan (ex-info "chan-err" {:x 1})))))))))
+        "awaiting a channel-carried error inside an async block re-throws it")
+    ;; and the error reaches the result channel AS an error value (the async error
+    ;; path fired) — never silently resolved as a normal datum.
+    (let [v (<!! (ca/->chan
+                  (async (await (ca/->cps (closed-chan (ex-info "chan-err" {})))))))]
+      (is (ca/error? v) "the bridged error arrives as an error value, never a datum")))
+  (testing "a SUCCESS value still resolves through the very same async/await path"
+    (is (= 5 (ca/unwrap-result
+              (<!! (ca/->chan (async (inc (await (ca/->cps (closed-chan 4))))))))))))
+
+(deftest sync-or-cps-passthrough-vs-wrap
+  (testing "{:sync? true} passes the value straight through"
+    (is (= 5 (ca/sync-or-cps 5 {:sync? true}))))
+  (testing "{:sync? false} wraps a channel result as an await-able CPS"
+    (is (= 5 (<!! (ca/->chan (ca/sync-or-cps (closed-chan 5) {:sync? false})))))))
+
+(deftest chan?-predicate
+  (is (true? (ca/chan? (chan))))
+  (is (false? (ca/chan? 42)))
+  (is (false? (ca/chan? (fn [_ _])))))


### PR DESCRIPTION
## What

Adds **`is.simm.partial-cps.core-async`** — a self-contained, **optional** adapter bridging `clojure.core.async` channels and partial-cps CPS values. **Both directions are non-blocking — the adapter never `<!!`s; deciding to block is the caller's concern, not the bridge's.**

- `->cps` / `chan->cps` — channel | value | cps → an `await`-able partial-cps CPS
- `->chan` / `unwrap-result` — cps | value | channel → a `core.async` channel (`<!`-able)
- `sync-or-cps` — a `:sync?`-aware result (value on sync / channel on async) → an `async+sync` bridge, non-blocking either way

## Error handling (superv.async convention)

An error is a `Throwable`/js-error **value** carried on the channel (or passed to a CPS `raise`); at each boundary throw it is re-wrapped in a **fresh `ex-info`** (message + `ex-data` preserved, original as `cause`), so a core.async error propagates into partial-cps — and back — with a full stack trace. Errors taken off a channel are routed into partial-cps's `raise` (error) continuation, never silently resolved. **No supervisor coupling** (no `-free-exception`), so it works with plain core.async too — the shared convention is just *error-as-a-value-on-the-channel*.

## Optional dependency

core.async is **not** a base dependency. The ns lives on its own `src-core-async` source path (added to `:paths` so it ships in the jar and `:local/root` consumers see it); only the `:core-async` / `:test` aliases pull core.async. `:format`/`:ffix` extended to cover `src-core-async`.

## Tests

`is.simm.partial-cps.core-async-test` (7 tests, JVM) — both bridge directions, error propagation into the partial-cps error path, and the rewrap (message/ex-data/cause preserved).

## Note

Also applies a pending cljfmt reformat to `ioc.clj` (pre-existing indentation drift) so the format check is clean.