### PR TITLE
feat: dual-mode foundation — async+sync, async-expr?, all

### DIFF
--- a/src/is/simm/partial_cps/async.cljc
+++ b/src/is/simm/partial_cps/async.cljc
@@ -138,14 +138,17 @@
    (defmacro async+sync
      "One body, two execution modes — the dual-mode foundation.
 
-   On :clj this emits ONLY the synchronous form (breakpoints stripped:
-   `(await x)` → x, nested `(async …)`/`(async+sync …)` → do): zero
-   overhead, no dead async arm in the bytecode, and `sync?` is not even
-   evaluated (it must be a pure expression).
-
-   On :cljs it emits `(if sync? <stripped-sync-form> (async body…))` —
+   Emits `(if sync? <direct-sync-form> (async body…))` on BOTH platforms —
    a runtime dispatch amortized at whatever frequency the enclosing
-   function is called.
+   function is called. `sync?` is honored everywhere: the CPS arm (with
+   its multi-shot, copyable continuations) is as available on the JVM as
+   on cljs.
+
+   When `sync?` is the LITERAL true or false the untaken arm is pruned at
+   compile time — zero overhead and no dead code. Consumers with a
+   platform-static mode (e.g. an engine that is always synchronous on the
+   JVM) should express that policy in a wrapper macro passing the literal,
+   not rely on the platform to imply it.
 
    The strip resolves symbols with the SAME resolution the async transform
    uses (an aliased or fully-qualified await strips; a breakpoint that is
@@ -159,11 +162,12 @@
      [sync? & body]
      (let [form (cons 'do body)
            ctx {:breakpoints breakpoints :env &env}]
-       (if (:js-globals &env)
-         `(if ~sync?
-            ~(ioc/strip-breakpoints form ctx)
-            (async ~@body))
-         (ioc/strip-breakpoints form ctx)))))
+       (cond
+         (true? sync?) (ioc/strip-breakpoints form ctx)
+         (false? sync?) `(async ~@body)
+         :else `(if ~sync?
+                  ~(ioc/strip-breakpoints form ctx)
+                  (async ~@body))))))
 
 (defn all
   "Async expression resolving to a vector of the results of `exprs` — each

--- a/src/is/simm/partial_cps/async.cljc
+++ b/src/is/simm/partial_cps/async.cljc
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.runtime :as runtime]
             #?(:clj [is.simm.partial-cps.ioc :as ioc :refer [has-breakpoints? invert]]))
-  #?(:cljs (:require-macros [is.simm.partial-cps.async :refer [async]])))
+  #?(:cljs (:require-macros [is.simm.partial-cps.async :refer [async async+sync]])))
 
 (defn await
   "Awaits the asynchronous execution of continuation-passing style function

--- a/src/is/simm/partial_cps/async.cljc
+++ b/src/is/simm/partial_cps/async.cljc
@@ -151,7 +151,11 @@
    uses (an aliased or fully-qualified await strips; a breakpoint that is
    also a macro, e.g. cljs.core/await, is matched before expansion), so no
    suspension point can survive into the sync arm and throw at runtime.
-   Locals named await/async inside the body are rejected at compile time."
+   The walk is env-threaded through binding forms, fn literals are opaque
+   in BOTH arms (a bare await inside one is a compile-time error — wrap the
+   fn body in its own (async …) if it should produce an async expression),
+   and locals named await/async inside the body are rejected at compile
+   time (the async arm cannot resolve the shadowing)."
      [sync? & body]
      (let [form (cons 'do body)
            ctx {:breakpoints breakpoints :env &env}]

--- a/src/is/simm/partial_cps/async.cljc
+++ b/src/is/simm/partial_cps/async.cljc
@@ -1,7 +1,7 @@
 (ns is.simm.partial-cps.async
   (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.runtime :as runtime]
-            #?(:clj [is.simm.partial-cps.ioc :refer [has-breakpoints? invert]]))
+            #?(:clj [is.simm.partial-cps.ioc :as ioc :refer [has-breakpoints? invert]]))
   #?(:cljs (:require-macros [is.simm.partial-cps.async :refer [async]])))
 
 (defn await
@@ -88,6 +88,18 @@
    ;; resolves, so this key is simply inert there.)
    'cljs.core/await `await-handler})
 
+(defn async-expr?
+  "Is x an asynchronous expression produced by the `async` macro (or `all`)?
+   Async expressions ARE plain 2-arity fns (fn? returns true — duck-typed
+   consumers keep working); this predicate is the reliable discriminator for
+   contracts where a fn-as-VALUE must be distinguished from an async return
+   (e.g. a query engine awaiting user functions that may themselves be
+   async). cljs: a property stamped on the emitted fn at creation.
+   clj: metadata (async exprs are rarely hot on the JVM)."
+  [x]
+  #?(:clj  (boolean (and (fn? x) (:is.simm.partial-cps/async (meta x))))
+     :cljs (boolean (and (fn? x) (true? (.-partial_cps_async_expr x))))))
+
 #?(:clj
    (defmacro async
      "Defines a function that takes a successful and exceptional continuation,
@@ -98,19 +110,96 @@
    A call of the form (breakpoint args..) is forwarded to the corresponding handler
    (handler succ exc args..), which is expected to eventually call either succ
    with the value or exc with exception to substitute the original call result
-   and resuming the execution."
+   and resuming the execution.
+
+   The returned fn is marked so `async-expr?` can identify it."
      [& body]
      (let [r (gensym) e (gensym)
            params {:r r :e e :env &env :breakpoints breakpoints}
-           form (cons 'do body)]
-       `(fn [~r ~e]
-          (try
-            (if *in-trampoline*
-              ~(invert params form)
-              (binding [*in-trampoline* true]
-                (loop [result# ~(invert params form)]
-                  (if (runtime/thunk? result#)
-                    ;; If continuation returns a thunk, trampoline it
-                    (recur (runtime/force-thunk result#))
-                    result#))))
-            (catch ~(if (:js-globals &env) :default `Throwable) t# (~e t#)))))))
+           form (cons 'do body)
+           fn-form `(fn [~r ~e]
+                      (try
+                        (if *in-trampoline*
+                          ~(invert params form)
+                          (binding [*in-trampoline* true]
+                            (loop [result# ~(invert params form)]
+                              (if (runtime/thunk? result#)
+                                ;; If continuation returns a thunk, trampoline it
+                                (recur (runtime/force-thunk result#))
+                                result#))))
+                        (catch ~(if (:js-globals &env) :default `Throwable) t# (~e t#))))]
+       (if (:js-globals &env)
+         `(let [f# ~fn-form]
+            (set! (.-partial_cps_async_expr f#) true)
+            f#)
+         `(with-meta ~fn-form {:is.simm.partial-cps/async true})))))
+
+#?(:clj
+   (defmacro async+sync
+     "One body, two execution modes — the dual-mode foundation.
+
+   On :clj this emits ONLY the synchronous form (breakpoints stripped:
+   `(await x)` → x, nested `(async …)`/`(async+sync …)` → do): zero
+   overhead, no dead async arm in the bytecode, and `sync?` is not even
+   evaluated (it must be a pure expression).
+
+   On :cljs it emits `(if sync? <stripped-sync-form> (async body…))` —
+   a runtime dispatch amortized at whatever frequency the enclosing
+   function is called.
+
+   The strip resolves symbols with the SAME resolution the async transform
+   uses (an aliased or fully-qualified await strips; a breakpoint that is
+   also a macro, e.g. cljs.core/await, is matched before expansion), so no
+   suspension point can survive into the sync arm and throw at runtime.
+   Locals named await/async inside the body are rejected at compile time."
+     [sync? & body]
+     (let [form (cons 'do body)
+           ctx {:breakpoints breakpoints :env &env}]
+       (if (:js-globals &env)
+         `(if ~sync?
+            ~(ioc/strip-breakpoints form ctx)
+            (async ~@body))
+         (ioc/strip-breakpoints form ctx)))))
+
+(defn all
+  "Async expression resolving to a vector of the results of `exprs` — each
+   an async expression — invoked IN ORDER, each driven to its first true
+   suspension (or completion) before the next launches. All-warm inputs
+   therefore complete synchronously and the whole `all` resolves before it
+   returns, preserving the trampoline's sync-completion property. Rejects
+   with the FIRST error; other branches keep running to completion (no
+   cancellation — partial-cps has no cancellation primitive). Each expr is
+   invoked exactly once. Empty input resolves to []."
+  [exprs]
+  (let [exprs (vec exprs)
+        n (count exprs)
+        f (fn [resolve reject]
+            (if (zero? n)
+              (invoke-continuation resolve [])
+              (let [results #?(:clj (object-array n) :cljs (make-array n))
+                    remaining (atom n)
+                    rejected? (atom false)]
+                (loop [i 0]
+                  (when (< i n)
+                    (let [t ((nth exprs i)
+                             (fn [v]
+                               (aset results i v)
+                               (when (and (zero? (swap! remaining dec))
+                                          (not @rejected?))
+                                 (invoke-continuation resolve (vec results))))
+                             (fn [err]
+                               (when (compare-and-set! rejected? false true)
+                                 (invoke-continuation reject err))))]
+                      ;; Drive this branch's Thunk chain NOW: when invoked
+                      ;; under an enclosing trampoline the branch RETURNS a
+                      ;; Thunk instead of forcing it (only one Thunk can
+                      ;; propagate to the enclosing loop), so `all` must run
+                      ;; each branch to its first real suspension itself.
+                      (loop [r t]
+                        (when (runtime/thunk? r)
+                          (recur (runtime/force-thunk r)))))
+                    (recur (inc i))))
+                nil)))]
+    #?(:cljs (set! (.-partial_cps_async_expr f) true))
+    #?(:clj (with-meta f {:is.simm.partial-cps/async true})
+       :cljs f)))

--- a/src/is/simm/partial_cps/ioc.clj
+++ b/src/is/simm/partial_cps/ioc.clj
@@ -297,8 +297,11 @@
                                  (mapv #(walk env %) vals-vec) (walk env default))
                   (meta f)))
               ;; clj: (case* ge shift mask default imap & args), imap {hash [const expr]}
+              ;; — rebuilt via (empty imap): the compiler depends on the imap's
+              ;; map TYPE/ordering for dispatch (a plain {} misdispatches)
               (let [[_ ge shift mask default imap & more] f
-                    imap' (reduce-kv (fn [m k [c e]] (assoc m k [c (walk env e)])) {} imap)]
+                    imap' (reduce-kv (fn [m k [c e]] (assoc m k [c (walk env e)]))
+                                     (empty imap) imap)]
                 (with-meta (list* 'case* ge shift mask (walk env default) imap' more)
                   (meta f)))))
           (walk [env f]
@@ -558,10 +561,11 @@
                 ;; Transform default expression
                 inverted-default (invert-impl ctx default-expr)]
             `(case* ~test-expr ~keys-vec ~inverted-vals ~inverted-default))
-          ;; CLJ format
+          ;; CLJ format — (empty imap) preserves the imap's map type/ordering,
+          ;; which the compiled case* dispatch depends on
           (let [[ge shift mask default imap & args] tail
                 imap (reduce-kv #(assoc %1 %2 (update %3 1 (fn [v] (invert-impl ctx v))))
-                                {} imap)]
+                                (empty imap) imap)]
             `(case* ~ge ~shift ~mask ~(invert-impl ctx default) ~imap ~@args)))
 
         let*

--- a/src/is/simm/partial_cps/ioc.clj
+++ b/src/is/simm/partial_cps/ioc.clj
@@ -170,7 +170,10 @@
                         fn*
                         (guard-shadowing!
                          (mapcat (fn [x] (cond (vector? x) x
-                                               (seq? x) (first x)
+                                               ;; arity form ([params] body…):
+                                               ;; only the PARAMS vector holds
+                                               ;; bindings — body forms do not
+                                               (and (seq? x) (vector? (first x))) (first x)
                                                :else nil))
                                  (rest f))
                          f)

--- a/src/is/simm/partial_cps/ioc.clj
+++ b/src/is/simm/partial_cps/ioc.clj
@@ -94,6 +94,95 @@
             (swap! breakpoint-cache assoc cache-key (boolean result)))
           result)))))
 
+(def ^:private pcps-async-sym 'is.simm.partial-cps.async/async)
+(def ^:private pcps-dual-sym 'is.simm.partial-cps.async/async+sync)
+
+(defn- macro-name
+  "Resolve sym to the fully-qualified name of the MACRO it refers to, or nil.
+   Needed because cljs.analyzer/resolve-var GUESSES a current-ns name for
+   unresolvable runtime symbols (macros have no runtime var), so var-name's
+   var-first `or` never reaches its macro fallback for macro-only names."
+  [env sym]
+  (when (and (symbol? sym) (not (special-symbol? sym)))
+    (if (:js-globals env)
+      (:name (resolve-macro-var-cljs env sym))
+      (when-let [v (resolve env sym)]
+        (when (:macro (meta v))
+          (let [m (meta v)]
+            (symbol (str (:ns m)) (name (:name m)))))))))
+
+(defn- guard-shadowing!
+  "Reject local bindings NAMED await/async inside a dual body: the sync-arm
+   strip resolves globally (it cannot see locals), so a shadowed await would
+   be stripped when the user meant the local — fail the build instead."
+  [syms form]
+  (doseq [s syms]
+    (when (and (symbol? s) (#{"await" "async"} (name s)))
+      (throw (ex-info (str "async+sync: locally binding `" s "` inside a dual "
+                           "body is unsupported (the sync-arm strip resolves "
+                           "globally and would rewrite it) — rename the local")
+                      {:binding s :form form})))))
+
+(defn strip-breakpoints
+  "Rewrite `form` to its SYNCHRONOUS shape:
+   - every resolved breakpoint call `(await x)` becomes `x`,
+   - a nested resolved `(async & body)` becomes `(do & body)`,
+   - a nested resolved `(async+sync s & body)` becomes `(do & body)`
+     (same-mode semantics: a synchronous context strips all the way down).
+   Resolution uses the SAME `var-name` lookup (after the same macroexpansion
+   discipline) as the async transform — a breakpoint is matched on the
+   ORIGINAL operator before expansion — so whatever the async arm would
+   treat as a suspension point, the sync arm un-suspends. An aliased or
+   fully-qualified await can therefore never survive into the sync arm
+   (where it would throw at runtime). Quoted forms are left untouched;
+   locals shadowing await/async are rejected at compile time."
+  [form {:keys [breakpoints env] :as ctx}]
+  (letfn [(walk [f]
+            (cond
+              (seq? f)
+              (let [head (first f)]
+                (cond
+                  (= 'quote head) f
+
+                  (and (symbol? head)
+                       (contains? breakpoints (var-name env head)))
+                  (do (assert (= 2 (count f))
+                              (str "breakpoint call must have exactly one argument: " f))
+                      (walk (second f)))
+
+                  (and (symbol? head)
+                       (= pcps-async-sym (macro-name env head)))
+                  (with-meta (cons 'do (map walk (rest f))) (meta f))
+
+                  (and (symbol? head)
+                       (= pcps-dual-sym (macro-name env head)))
+                  (with-meta (cons 'do (map walk (drop 2 f))) (meta f))
+
+                  :else
+                  (if-let [[expanded _] (expand-macro f env)]
+                    (walk expanded)
+                    (do
+                      (case head
+                        (let* loop*)
+                        (guard-shadowing! (take-nth 2 (second f)) f)
+                        letfn*
+                        (guard-shadowing! (take-nth 2 (second f)) f)
+                        fn*
+                        (guard-shadowing!
+                         (mapcat (fn [x] (cond (vector? x) x
+                                               (seq? x) (first x)
+                                               :else nil))
+                                 (rest f))
+                         f)
+                        nil)
+                      (with-meta (apply list (map walk f)) (meta f))))))
+
+              (vector? f) (with-meta (mapv walk f) (meta f))
+              (map? f) (into (empty f) (map (fn [[k v]] [(walk k) (walk v)])) f)
+              (set? f) (into (empty f) (map walk) f)
+              :else f))]
+    (walk form)))
+
 (defn can-inline?
   [form]
   (or (not (coll? form)) ; inline non-collection literals and symbols

--- a/src/is/simm/partial_cps/ioc.clj
+++ b/src/is/simm/partial_cps/ioc.clj
@@ -58,8 +58,14 @@
       ;; A registered breakpoint is TERMINAL: match it on the ORIGINAL operator WITHOUT
       ;; macroexpanding, so a breakpoint that is ALSO a macro (e.g. `cljs.core/await` on
       ;; cljs >= 1.12) is never expanded (its expansion would fire the macro's own assert).
+      ;; :extra-site? extends what counts as a site (the direct emitter counts nested
+      ;; async/async+sync forms — same-mode semantics rewrite them too). Callers using
+      ;; :extra-site? must supply their OWN cache atoms — cache entries are
+      ;; site-predicate-dependent.
       (if (and (seq? form) (symbol? (first form))
-               (contains? breakpoints (var-name env (first form))))
+               (or (contains? breakpoints (var-name env (first form)))
+                   (when-let [extra (:extra-site? ctx)]
+                     (extra env (first form)))))
         (do (when cache-key (swap! breakpoint-cache assoc cache-key true)) true)
         (let [[form-to-check ctx'] (if-let [cached (when expansion-cache (get @expansion-cache form))]
                                      [cached ctx]
@@ -74,7 +80,9 @@
                                        [form ctx]))
               sym (when (seq? form-to-check) (first form-to-check))
               resolved-sym (var-name env sym)
-              has-term? (contains? breakpoints resolved-sym)
+              has-term? (or (contains? breakpoints resolved-sym)
+                            (boolean (when-let [extra (:extra-site? ctx)]
+                                       (and (symbol? sym) (extra env sym)))))
               result (cond
                        has-term? true
 
@@ -111,17 +119,120 @@
           (let [m (meta v)]
             (symbol (str (:ns m)) (name (:name m)))))))))
 
+(defn binding-symbols
+  "All symbols BOUND by a binding form: plain symbols, & rest args, vector and
+   map destructuring (:keys/:syms/:strs incl. namespaced, :as aliases, nested
+   forms), ignoring :or defaults and `&` itself."
+  [x]
+  (cond
+    (symbol? x) (when-not (= '& x) [x])
+    (vector? x) (mapcat binding-symbols x)
+    (map? x) (mapcat (fn [[k v]]
+                       (cond
+                         (and (keyword? k) (#{"keys" "syms" "strs"} (name k)))
+                         (map (comp symbol name) v)
+                         (= :as k) [v]
+                         (= :or k) nil
+                         (keyword? k) nil
+                         :else (binding-symbols k)))
+                     x)
+    :else nil))
+
+(defn bind-locals
+  "Extend the macroexpansion env so `var-name`/`expand-macro` see `syms` as
+   locals: on clj `&env` is a map keyed by local symbols (`resolve` only
+   checks key presence); on cljs the analyzer looks in `:locals`."
+  [env syms]
+  (if (:js-globals env)
+    (update env :locals (fnil into {}) (map (fn [s] [s {:name s}])) syms)
+    (into (or env {}) (map (fn [s] [s true])) syms)))
+
 (defn- guard-shadowing!
-  "Reject local bindings NAMED await/async inside a dual body: the sync-arm
-   strip resolves globally (it cannot see locals), so a shadowed await would
-   be stripped when the user meant the local — fail the build instead."
+  "Reject local bindings NAMED await/async inside a dual body. The sync-arm
+   strip is env-threaded and would resolve the local correctly — but the
+   ASYNC arm's transform cannot (on cljs its env extension does not reach the
+   analyzer's :locals), so the two arms would diverge. Fail the build instead."
   [syms form]
   (doseq [s syms]
     (when (and (symbol? s) (#{"await" "async"} (name s)))
       (throw (ex-info (str "async+sync: locally binding `" s "` inside a dual "
-                           "body is unsupported (the sync-arm strip resolves "
-                           "globally and would rewrite it) — rename the local")
+                           "body is unsupported (the async arm would still "
+                           "treat it as a suspension point) — rename the local")
                       {:binding s :form form})))))
+
+(defn assert-no-bare-breakpoints!
+  "Closures are OPAQUE to the CPS transform: a bare breakpoint inside a
+   `fn*`/`reify*`/`deftype*` body can never suspend, so it is a compile-time
+   error in BOTH arms rather than a silent divergence (the strip used to
+   erase it, the async arm left it to fail at runtime). Nested
+   `async`/`async+sync` bodies open their own transform scope and are
+   skipped — a fn CONSTRUCTING an async expression is a value and legal.
+   Env-threaded so locals shadowing a breakpoint name (fn self-name, params,
+   lets) are not false positives. Breakpoints hidden behind unexpanded user
+   macros are not detected (the closure is never expanded by either arm)."
+  [form {:keys [breakpoints env]} outer-form]
+  (letfn [(scan-fn* [env f]
+            (let [tail (rest f)
+                  [nm tail] (if (symbol? (first tail))
+                              [(first tail) (rest tail)]
+                              [nil tail])
+                  env (if nm (bind-locals env [nm]) env)
+                  arities (if (vector? (first tail)) [tail] tail)]
+              (doseq [[params & body] arities]
+                (let [env' (bind-locals env (binding-symbols params))]
+                  (run! #(scan env' %) body)))))
+          (scan [env f]
+            (cond
+              (seq? f)
+              (let [head (first f)]
+                (cond
+                  (= 'quote head) nil
+
+                  (and (symbol? head)
+                       (or (= pcps-async-sym (macro-name env head))
+                           (= pcps-dual-sym (macro-name env head))))
+                  nil
+
+                  (and (symbol? head)
+                       (contains? breakpoints (var-name env head)))
+                  (throw (ex-info (str "breakpoint `" head "` inside a fn literal can "
+                                       "never suspend (closures are opaque to the CPS "
+                                       "transform) — hoist it out of the fn, or make the "
+                                       "fn body its own (async ...)")
+                                  {:breakpoint head :fn-form outer-form :site f}))
+
+                  :else
+                  (case head
+                    (let* loop*)
+                    (let [[_ bindings & body] f]
+                      (loop [env env, ps (seq (partition 2 bindings))]
+                        (if-let [[[b e] & more] ps]
+                          (do (scan env e)
+                              (recur (bind-locals env (binding-symbols b)) more))
+                          (run! #(scan env %) body))))
+
+                    fn*
+                    (scan-fn* env f)
+
+                    letfn*
+                    (let [[_ bindings & body] f
+                          env' (bind-locals env (take-nth 2 bindings))]
+                      ;; fn names are in scope in every fn body (mutual recursion)
+                      (run! #(scan env' %) (take-nth 2 (rest bindings)))
+                      (run! #(scan env' %) body))
+
+                    catch
+                    (let [[_ _cls b & body] f
+                          env' (bind-locals env [b])]
+                      (run! #(scan env' %) body))
+
+                    (run! #(scan env %) f))))
+              (coll? f) (run! #(scan env %) f)
+              :else nil))]
+    (scan env form))
+  nil)
+
+(declare strip-breakpoints*)
 
 (defn strip-breakpoints
   "Rewrite `form` to its SYNCHRONOUS shape:
@@ -132,13 +243,69 @@
    Resolution uses the SAME `var-name` lookup (after the same macroexpansion
    discipline) as the async transform — a breakpoint is matched on the
    ORIGINAL operator before expansion — so whatever the async arm would
-   treat as a suspension point, the sync arm un-suspends. An aliased or
-   fully-qualified await can therefore never survive into the sync arm
-   (where it would throw at runtime). Quoted forms are left untouched;
-   locals shadowing await/async are rejected at compile time."
+   treat as a suspension point, the sync arm un-suspends.
+
+   The walk is ENV-THREADED: locals introduced by let*/loop*/letfn*/catch
+   extend the resolution env, so macros expanding inside the body see their
+   enclosing locals in &env, and resolution matches the compiler's scoping.
+   fn*/reify*/deftype* are OPAQUE (matching the async transform, which never
+   descends into closures); a bare breakpoint inside one is a compile-time
+   error via `assert-no-bare-breakpoints!`. `(. obj (method args))` member
+   position is never treated as call position. Quoted forms are untouched;
+   locals shadowing await/async are rejected at compile time (the async arm
+   cannot handle them).
+
+   CAVEAT: macros in the body are expanded eagerly at strip time and the
+   expansion is emitted — an &env-sensitive macro sees the threaded env of
+   this walk, which now includes body locals, but expansion happens once per
+   arm and the two arms expand independently.
+
+   Site-free subtrees are emitted VERBATIM (the direct-emission analogue of
+   the CPS emitter's `(r form)` fast path): `has-breakpoints?` with an
+   :extra-site? counting nested async/async+sync forms decides, over caches
+   private to this walk (cache entries are site-predicate-dependent, so they
+   must never be shared with an invert pass)."
   [form {:keys [breakpoints env] :as ctx}]
-  (letfn [(walk [f]
+  (let [ctx (assoc ctx
+                   :extra-site? (fn [env head]
+                                  (or (= pcps-async-sym (macro-name env head))
+                                      (= pcps-dual-sym (macro-name env head))))
+                   :expansion-cache (atom {})
+                   :breakpoint-cache (atom {}))]
+    (strip-breakpoints* form ctx)))
+
+(defn- strip-breakpoints*
+  [form {:keys [breakpoints env] :as ctx}]
+  (letfn [(site-free? [env f]
+            (not (has-breakpoints? f (assoc ctx :env env))))
+          (walk-bindings [env bindings]
+            ;; sequential let-semantics: each init sees the previous bindings
+            (loop [env env, ps (seq (partition 2 bindings)), out []]
+              (if-let [[[b e] & more] ps]
+                (let [e' (walk env e)
+                      syms (binding-symbols b)]
+                  (guard-shadowing! syms bindings)
+                  (recur (bind-locals env syms) more (conj out b e')))
+                [env out])))
+          (walk-case* [env f]
+            ;; only RESULT positions are expressions; test constants must not
+            ;; be walked (a list-shaped constant is not a call)
+            (if (:js-globals env)
+              ;; cljs: (case* test keys-vec vals-vec default)
+              (let [[_ test keys-vec vals-vec default] f]
+                (with-meta (list 'case* (walk env test) keys-vec
+                                 (mapv #(walk env %) vals-vec) (walk env default))
+                  (meta f)))
+              ;; clj: (case* ge shift mask default imap & args), imap {hash [const expr]}
+              (let [[_ ge shift mask default imap & more] f
+                    imap' (reduce-kv (fn [m k [c e]] (assoc m k [c (walk env e)])) {} imap)]
+                (with-meta (list* 'case* ge shift mask (walk env default) imap' more)
+                  (meta f)))))
+          (walk [env f]
             (cond
+              ;; verbatim fast path: nothing to rewrite anywhere below
+              (site-free? env f) f
+
               (seq? f)
               (let [head (first f)]
                 (cond
@@ -148,43 +315,69 @@
                        (contains? breakpoints (var-name env head)))
                   (do (assert (= 2 (count f))
                               (str "breakpoint call must have exactly one argument: " f))
-                      (walk (second f)))
+                      (walk env (second f)))
 
                   (and (symbol? head)
                        (= pcps-async-sym (macro-name env head)))
-                  (with-meta (cons 'do (map walk (rest f))) (meta f))
+                  (with-meta (cons 'do (map #(walk env %) (rest f))) (meta f))
 
                   (and (symbol? head)
                        (= pcps-dual-sym (macro-name env head)))
-                  (with-meta (cons 'do (map walk (drop 2 f))) (meta f))
+                  (with-meta (cons 'do (map #(walk env %) (drop 2 f))) (meta f))
+
+                  ;; (. obj member) / (. obj (method args…)) / (. obj method args…):
+                  ;; the member position is not call position — never resolve it
+                  (= '. head)
+                  (let [[_ target & more] f
+                        fix (fn [m] (if (seq? m)
+                                      (with-meta (cons (first m) (map #(walk env %) (rest m)))
+                                        (meta m))
+                                      (walk env m)))]
+                    (with-meta (list* '. (walk env target) (map fix more)) (meta f)))
 
                   :else
                   (if-let [[expanded _] (expand-macro f env)]
-                    (walk expanded)
-                    (do
-                      (case head
-                        (let* loop*)
-                        (guard-shadowing! (take-nth 2 (second f)) f)
-                        letfn*
-                        (guard-shadowing! (take-nth 2 (second f)) f)
-                        fn*
-                        (guard-shadowing!
-                         (mapcat (fn [x] (cond (vector? x) x
-                                               ;; arity form ([params] body…):
-                                               ;; only the PARAMS vector holds
-                                               ;; bindings — body forms do not
-                                               (and (seq? x) (vector? (first x))) (first x)
-                                               :else nil))
-                                 (rest f))
-                         f)
-                        nil)
-                      (with-meta (apply list (map walk f)) (meta f))))))
+                    (walk env expanded)
+                    (case head
+                      (fn* reify* deftype*)
+                      (do (assert-no-bare-breakpoints! f (assoc ctx :env env) f)
+                          f)
 
-              (vector? f) (with-meta (mapv walk f) (meta f))
-              (map? f) (into (empty f) (map (fn [[k v]] [(walk k) (walk v)])) f)
-              (set? f) (into (empty f) (map walk) f)
+                      (let* loop*)
+                      (let [[_ bindings & body] f
+                            [env' bindings'] (walk-bindings env bindings)]
+                        (with-meta
+                          (list* head (vec bindings') (map #(walk env' %) body))
+                          (meta f)))
+
+                      letfn*
+                      (let [[_ bindings & body] f
+                            names (take-nth 2 bindings)
+                            _ (guard-shadowing! names f)
+                            env' (bind-locals env names)]
+                        (with-meta
+                          (list* 'letfn*
+                                 (vec (map-indexed (fn [i x] (if (odd? i) (walk env' x) x))
+                                                   bindings))
+                                 (map #(walk env' %) body))
+                          (meta f)))
+
+                      catch
+                      (let [[_ cls b & body] f
+                            _ (guard-shadowing! [b] f)
+                            env' (bind-locals env [b])]
+                        (with-meta (list* 'catch cls b (map #(walk env' %) body)) (meta f)))
+
+                      case*
+                      (walk-case* env f)
+
+                      (with-meta (apply list (map #(walk env %) f)) (meta f))))))
+
+              (vector? f) (with-meta (mapv #(walk env %) f) (meta f))
+              (map? f) (into (empty f) (map (fn [[k v]] [(walk env k) (walk env v)])) f)
+              (set? f) (into (empty f) (map #(walk env %)) f)
               :else f))]
-    (walk form)))
+    (walk env form)))
 
 (defn can-inline?
   [form]
@@ -221,10 +414,10 @@
       (then coll))))
 
 (defn add-env-syms [ctx syms]
-  ;; This adds mappings to "true" into the environment map. This doesn't quite
-  ;; match what the Clojure compiler does, but I think it's already recommended
-  ;; that macros don't depend on the values in the &env map.
-  (update ctx :env (fnil into {}) (map (fn [sym] [sym true])) syms))
+  ;; Extend the transform env with locals via `bind-locals` — on clj that is
+  ;; a key-presence entry (`resolve` only checks contains?), on cljs it must
+  ;; reach the analyzer's :locals or shadowing stays invisible to resolution.
+  (update ctx :env bind-locals syms))
 
 (defn handle-binding-form
   "Handle binding/with-redefs forms to restore bindings in continuations.
@@ -329,8 +522,14 @@
       (or (special-symbol? head) (= head 'let) (= head 'letfn) (= head 'loop) (= head 'fn))
       (case head
 
-        (quote var fn* fn deftype* reify* clojure.core/import*)
+        (quote var clojure.core/import*)
         `(~r ~form)
+
+        (fn* fn deftype* reify*)
+        ;; closures are opaque to the transform: a bare breakpoint inside can
+        ;; never suspend — reject at compile time instead of failing at runtime
+        (do (assert-no-bare-breakpoints! form ctx form)
+            `(~r ~form))
 
         if
         (let [[con left right & unexpected-others] tail
@@ -513,10 +712,17 @@
         (throw (ex-info (str "Unsupported special symbol [" head "]")
                         {:unknown-special-form head :form form})))
 
-      ;; Invoke termination handler, e.g. do-await
+      ;; Invoke termination handler, e.g. do-await — unless this arm ERASES
+      ;; the breakpoint (interpretation :erase — the site is not a suspension
+      ;; point here; inline its single argument and keep transforming)
       (contains? breakpoints (var-name env head))
-      (let [handler (resolve (breakpoints (var-name env head)))]
-        (resolve-sequentially ctx (rest form) (handler ctx r e)))
+      (let [bp (var-name env head)]
+        (if (= :erase (get (:interpretations ctx) bp))
+          (do (assert (= 2 (count form))
+                      (str "breakpoint call must have exactly one argument: " form))
+              (invert-impl ctx (second form)))
+          (let [handler (resolve (breakpoints bp))]
+            (resolve-sequentially ctx (rest form) (handler ctx r e)))))
 
       (seq? form)
       (resolve-sequentially ctx form (fn [form] `(~r ~(seq form))))

--- a/test/is/simm/partial_cps/async_test.cljs
+++ b/test/is/simm/partial_cps/async_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :as test :refer-macros [deftest testing is]]
             [is.simm.partial-cps.async :refer [await]]
             [clojure.pprint :refer [pprint]]
+            [is.simm.partial-cps.dual-mode-test]
             [is.simm.partial-cps.sequence-test :as sequence]
             [is.simm.partial-cps.for-async-test :as for-async]
             [is.simm.partial-cps.core-test :as core-test])
@@ -157,6 +158,7 @@
 ;; Test runner
 (defn ^:export run-tests []
   (test/run-tests 'is.simm.partial-cps.async-test)
+  (test/run-tests 'is.simm.partial-cps.dual-mode-test)
   (test/run-tests 'is.simm.partial-cps.sequence-test)
   (test/run-tests 'is.simm.partial-cps.for-async-test)
   (test/run-tests 'is.simm.partial-cps.core-test))

--- a/test/is/simm/partial_cps/dual_mode_test.clj
+++ b/test/is/simm/partial_cps/dual_mode_test.clj
@@ -1,21 +1,48 @@
 (ns is.simm.partial-cps.dual-mode-test
-  "JVM side of the dual-mode foundation: async+sync emits ONLY the stripped
-   synchronous form on :clj (no dead async arm, sync? not evaluated), the
-   strip is hygienic (aliased/qualified await strips; shadowing rejected at
-   compile time; quotes untouched), and `all`/`async-expr?` behave."
+  "JVM side of the dual-mode foundation: async+sync honors sync? at runtime
+   on BOTH platforms (literal sync? prunes the untaken arm at compile time),
+   the CPS arm's continuations are multi-shot plain closures, the direct
+   emitter is hygienic (aliased/qualified await erases; colliding shadowing
+   rejected; closures opaque; quotes untouched), and `all`/`async-expr?`
+   behave."
   (:require [clojure.test :refer [deftest is testing]]
             [is.simm.partial-cps.async :as pa :refer [async async+sync all async-expr? await]]))
 
-(deftest clj-emits-sync-only
-  (testing "dual body returns the plain value on the JVM"
+(deftest dual-honors-sync-on-jvm
+  (testing "sync? true runs the direct arm and returns the plain value"
     (let [f (fn [x sync?] (async+sync sync? (+ 1 (await (async (* 2 x))))))]
-      ;; sync? is irrelevant on :clj — both calls run the stripped form
-      (is (= 7 (f 3 true)))
-      (is (= 7 (f 3 false)))))
-  (testing "sync? expression is NOT evaluated on :clj"
+      (is (= 7 (f 3 true)))))
+  (testing "sync? false returns the CPS arm — an async expression — on the
+            JVM too (the async arm is not a cljs-only capability)"
+    (let [f (fn [x sync?] (async+sync sync? (+ 1 (await (async (* 2 x))))))
+          e (f 3 false)
+          r (atom nil)]
+      (is (async-expr? e))
+      (e #(reset! r %) #(reset! r [:err %]))
+      (is (= 7 @r))))
+  (testing "a LITERAL sync? prunes the untaken arm at compile time (no
+            evaluation, no dead code)"
+    ;; literal true → direct arm only; the async machinery is absent
+    (is (= 5 (async+sync true (+ 2 3))))
+    ;; non-literal sync? IS evaluated now (runtime dispatch — sound)
     (let [evals (atom 0)]
       (is (= 5 (async+sync (do (swap! evals inc) true) (+ 2 3))))
-      (is (zero? @evals)))))
+      (is (= 1 @evals)))))
+
+(deftest continuations-are-multi-shot
+  (testing "a continuation is a plain closure: an awaited expression that
+            resolves TWICE runs the downstream body twice (amb/fork-replay/
+            inference-style re-execution) — on the JVM"
+    (let [runs (atom [])
+          double-resolve (fn [res _rej] (res 1) (res 10))
+          e (async+sync false
+                        (let [v (await double-resolve)]
+                          (swap! runs conj (+ v 100))
+                          v))
+          results (atom [])]
+      (e #(swap! results conj %) #(swap! results conj [:err %]))
+      (is (= [101 110] @runs) "downstream body ran once per resolution")
+      (is (= [1 10] @results) "outer continuation delivered both completions"))))
 
 (deftest strip-hygiene
   (testing "ALIASED await strips (the konserve/PSS bare-symbol strip missed this)"
@@ -89,8 +116,8 @@
                  (eval '(is.simm.partial-cps.async/async+sync true
                                                               (try (is.simm.partial-cps.async/async 1)
                                                                    (catch Exception await
-                                                                          (is.simm.partial-cps.async/await
-                                                                           (is.simm.partial-cps.async/async 2))))))))))
+                                                                     (is.simm.partial-cps.async/await
+                                                                      (is.simm.partial-cps.async/async 2))))))))))
 
 (deftest all-on-jvm
   (testing "empty input resolves []"

--- a/test/is/simm/partial_cps/dual_mode_test.clj
+++ b/test/is/simm/partial_cps/dual_mode_test.clj
@@ -30,10 +30,54 @@
     (is (= 43 (async+sync true (-> (await (async 42)) inc))))))
 
 (deftest shadowing-rejected
-  (testing "locally binding await inside a dual body fails at compile time"
+  (testing "shadowing that COLLIDES with an in-scope breakpoint fails at
+            compile time (the async arm would still treat the call as a
+            suspension point)"
     (is (thrown? Exception
                  (eval '(is.simm.partial-cps.async/async+sync true
-                                                              (let [await inc] (await 1))))))))
+                                                              (let [await inc]
+                                                                (is.simm.partial-cps.async/await 1)))))))
+  (testing "shadowing that does NOT collide (await resolves elsewhere, e.g.
+            clojure.core/await) is site-free: emitted verbatim and correct"
+    (is (= 2 (eval '(is.simm.partial-cps.async/async+sync true
+                                                          (let [await inc] (await 1))))))))
+
+(deftest closures-are-opaque
+  (testing "a bare breakpoint inside a fn literal is a compile-time error in
+            the dual macro (it could never suspend — closures are opaque)"
+    (is (thrown? Exception
+                 (eval '(is.simm.partial-cps.async/async+sync true
+                                                              ((fn [x] (is.simm.partial-cps.async/await x)) 1))))))
+  (testing "…and in the plain async macro too"
+    (is (thrown? Exception
+                 (eval '(is.simm.partial-cps.async/async
+                         ((fn [x] (is.simm.partial-cps.async/await x)) 1))))))
+  (testing "a fn CONSTRUCTING an async expression is a value and legal"
+    (let [make (async+sync true (fn [x] (async (inc (await (async x))))))
+          r (atom nil)]
+      ((make 41) #(reset! r %) #(reset! r [:err %]))
+      (is (= 42 @r))))
+  (testing "a fn self-named await does not false-positive the scan"
+    (is (fn? (async+sync true (fn await [x] x))))))
+
+(deftest special-form-edges
+  (testing "(. obj (method args)) member position is not call position"
+    (is (= "bc" (async+sync true (. "abc" (substring (await (async 1))))))))
+  (testing "case with seq-shaped test constants compiles and strips"
+    (is (= :a (async+sync true (case (await (async 1)) (1 2) :a :b)))))
+  (testing "a catch binding shadowing await is fine while unused (site-free,
+            verbatim) …"
+    (is (= 1 (eval '(is.simm.partial-cps.async/async+sync true
+                                                          (try (is.simm.partial-cps.async/await
+                                                                (is.simm.partial-cps.async/async 1))
+                                                               (catch Exception await 2)))))))
+  (testing "…but rejected when the shadowed name is called as a breakpoint"
+    (is (thrown? Exception
+                 (eval '(is.simm.partial-cps.async/async+sync true
+                                                              (try (is.simm.partial-cps.async/async 1)
+                                                                   (catch Exception await
+                                                                          (is.simm.partial-cps.async/await
+                                                                           (is.simm.partial-cps.async/async 2))))))))))
 
 (deftest all-on-jvm
   (testing "empty input resolves []"

--- a/test/is/simm/partial_cps/dual_mode_test.clj
+++ b/test/is/simm/partial_cps/dual_mode_test.clj
@@ -65,6 +65,19 @@
     (is (= "bc" (async+sync true (. "abc" (substring (await (async 1))))))))
   (testing "case with seq-shaped test constants compiles and strips"
     (is (= :a (async+sync true (case (await (async 1)) (1 2) :a :b)))))
+  (testing "KEYWORD-dispatch case keeps its imap type through the walk
+            (a plain {} rebuild misdispatches the compiled hash case*)"
+    (is (= [:add :retract :other]
+           (async+sync true
+                       (mapv (fn [op] (case op
+                                        :db/add :add
+                                        :db/retract :retract
+                                        :other))
+                             [:db/add :db/retract :db/x]))))
+    (is (= :add (async+sync true (case (await (async :db/add))
+                                   :db/add :add
+                                   :db/retract :retract
+                                   :other)))))
   (testing "a catch binding shadowing await is fine while unused (site-free,
             verbatim) …"
     (is (= 1 (eval '(is.simm.partial-cps.async/async+sync true

--- a/test/is/simm/partial_cps/dual_mode_test.clj
+++ b/test/is/simm/partial_cps/dual_mode_test.clj
@@ -1,0 +1,67 @@
+(ns is.simm.partial-cps.dual-mode-test
+  "JVM side of the dual-mode foundation: async+sync emits ONLY the stripped
+   synchronous form on :clj (no dead async arm, sync? not evaluated), the
+   strip is hygienic (aliased/qualified await strips; shadowing rejected at
+   compile time; quotes untouched), and `all`/`async-expr?` behave."
+  (:require [clojure.test :refer [deftest is testing]]
+            [is.simm.partial-cps.async :as pa :refer [async async+sync all async-expr? await]]))
+
+(deftest clj-emits-sync-only
+  (testing "dual body returns the plain value on the JVM"
+    (let [f (fn [x sync?] (async+sync sync? (+ 1 (await (async (* 2 x))))))]
+      ;; sync? is irrelevant on :clj — both calls run the stripped form
+      (is (= 7 (f 3 true)))
+      (is (= 7 (f 3 false)))))
+  (testing "sync? expression is NOT evaluated on :clj"
+    (let [evals (atom 0)]
+      (is (= 5 (async+sync (do (swap! evals inc) true) (+ 2 3))))
+      (is (zero? @evals)))))
+
+(deftest strip-hygiene
+  (testing "ALIASED await strips (the konserve/PSS bare-symbol strip missed this)"
+    (is (= 42 (async+sync true (pa/await (async 42))))))
+  (testing "fully-qualified await strips"
+    (is (= 42 (async+sync true (is.simm.partial-cps.async/await (async 42))))))
+  (testing "nested async+sync strips as same-mode"
+    (is (= 10 (async+sync true (+ 1 (async+sync true (pa/await (async 9))))))))
+  (testing "quoted forms are untouched"
+    (is (= '(await x) (async+sync true (quote (await x))))))
+  (testing "await inside a threading macro strips (macroexpansion parity)"
+    (is (= 43 (async+sync true (-> (await (async 42)) inc))))))
+
+(deftest shadowing-rejected
+  (testing "locally binding await inside a dual body fails at compile time"
+    (is (thrown? Exception
+                 (eval '(is.simm.partial-cps.async/async+sync true
+                                                              (let [await inc] (await 1))))))))
+
+(deftest all-on-jvm
+  (testing "empty input resolves []"
+    (let [r (atom ::pending)]
+      ((all []) (fn [v] (reset! r v)) (fn [e] (reset! r [:err e])))
+      (is (= [] @r))))
+  (testing "warm branches resolve synchronously, in order"
+    (let [r (atom ::pending)]
+      ((all [(async 1) (async 2) (async 3)])
+       (fn [v] (reset! r v)) (fn [e] (reset! r [:err e])))
+      (is (= [1 2 3] @r))))
+  (testing "first error rejects; result never resolves"
+    (let [r (atom ::pending)]
+      ((all [(async 1) (async (throw (ex-info "boom" {}))) (async 3)])
+       (fn [v] (reset! r [:resolved v]))
+       (fn [e] (reset! r [:err (ex-message e)])))
+      (is (= [:err "boom"] @r))))
+  (testing "each expr invoked exactly once"
+    (let [invocations (atom 0)
+          expr (fn [resolve _reject] (swap! invocations inc) (resolve 1) nil)
+          r (atom ::pending)]
+      ((all [expr expr]) (fn [v] (reset! r v)) (fn [_] nil))
+      (is (= [1 1] @r))
+      (is (= 2 @invocations)))))
+
+(deftest marker
+  (is (async-expr? (async 42)))
+  (is (async-expr? (all [(async 1)])))
+  (is (not (async-expr? (fn [a b] (a 1)))))
+  (is (not (async-expr? 42)))
+  (is (not (async-expr? nil))))

--- a/test/is/simm/partial_cps/dual_mode_test.cljs
+++ b/test/is/simm/partial_cps/dual_mode_test.cljs
@@ -1,0 +1,71 @@
+(ns is.simm.partial-cps.dual-mode-test
+  "JS side of the dual-mode foundation: async+sync dispatches at runtime
+   (sync? true → stripped form runs on the calling stack and RETURNS the
+   value; false → async expr), all-warm `all` resolves before returning,
+   deferred branches gather concurrently, first-error rejects, and warm
+   awaits inside deep loops keep the stack constant (trampoline stress)."
+  (:require [cljs.test :as test :refer-macros [is deftest testing]]
+            [is.simm.partial-cps.async :as pa :refer [all async-expr?]
+             :refer-macros [async async+sync]]))
+
+(defn- resolve-now!
+  "Invoke an async expr; return the value if it resolved synchronously,
+   ::pending otherwise."
+  [expr]
+  (let [r (atom ::pending)]
+    (expr (fn [v] (reset! r v)) (fn [e] (reset! r [::err e])))
+    @r))
+
+(deftest dual-dispatch
+  (testing "sync? true: stripped form, plain value returned"
+    (let [f (fn [x sync?] (async+sync sync? (+ 1 (pa/await (async (* 2 x))))))]
+      (is (= 7 (f 3 true)))))
+  (testing "sync? false: async expr, warm → resolves on the calling stack"
+    (let [f (fn [x sync?] (async+sync sync? (+ 1 (pa/await (async (* 2 x))))))
+          expr (f 3 false)]
+      (is (async-expr? expr))
+      (is (= 7 (resolve-now! expr)))))
+  (testing "aliased await strips in the sync arm (hygiene)"
+    (is (= 42 (async+sync true (pa/await (async 42)))))))
+
+(deftest all-warm-sync-completion
+  (testing "all-warm all resolves BEFORE returning, in order"
+    (is (= [1 2 3] (resolve-now! (all [(async 1) (async 2) (async 3)])))))
+  (testing "empty"
+    (is (= [] (resolve-now! (all [])))))
+  (testing "first error rejects"
+    (let [r (resolve-now! (all [(async 1) (async (throw (ex-info "boom" {})))]))]
+      (is (vector? r))
+      (is (= ::err (first r))))))
+
+(deftest all-deferred-gather
+  (test/async done
+              (let [deferred (fn [v ms]
+                               (let [f (fn [resolve _reject]
+                                         (js/setTimeout #(pa/invoke-continuation resolve v) ms)
+                                         nil)]
+                                 (set! (.-partial_cps_async_expr f) true)
+                                 f))]
+                ((all [(deferred :a 20) (async :warm) (deferred :b 5)])
+                 (fn [v]
+                   (is (= [:a :warm :b] v) "order preserved regardless of completion order")
+                   (done))
+                 (fn [e]
+                   (is (nil? e) "all rejected unexpectedly")
+                   (done))))))
+
+(deftest trampoline-depth-stress
+  (testing "100k warm awaits inside one async loop keep the stack constant"
+    (let [expr (async
+                (loop [i 0 acc 0]
+                  (if (< i 100000)
+                    (recur (inc i) (+ acc (pa/await (async 1))))
+                    acc)))]
+      (is (= 100000 (resolve-now! expr)))))
+  (testing "all over 10k warm branches completes synchronously"
+    (let [r (resolve-now! (all (vec (for [i (range 10000)] (async i)))))]
+      (is (= 10000 (count r)))
+      (is (= 49995000 (reduce + r))))))
+
+(defn ^:export run []
+  (test/run-tests 'is.simm.partial-cps.dual-mode-test))

--- a/test/is/simm/partial_cps/equivalence_test.clj
+++ b/test/is/simm/partial_cps/equivalence_test.clj
@@ -1,0 +1,117 @@
+(ns is.simm.partial-cps.equivalence-test
+  "The dual-mode law as a generative property: for any body in the supported
+   grammar, the stripped sync arm and the CPS async arm run all-warm must
+   agree on (1) result value, (2) side-effect order, (3) thrown exception
+   class. Deterministic: seeded generator, identical corpus every run.
+
+   This is the library-owned form of the law its consumers rely on
+   (sync ≡ async-all-warm); it gates any refactor of the transform."
+  (:require [clojure.test :refer [deftest is]]
+            [is.simm.partial-cps.async :as pa :refer [async async+sync await]]))
+
+;; ---------------------------------------------------------------------------
+;; deterministic generator
+
+(defn- pick [^java.util.Random r coll]
+  (let [v (vec coll)] (nth v (.nextInt r (count v)))))
+
+(defn- rint [^java.util.Random r n] (.nextInt r (int n)))
+
+(defn gen-expr
+  "Generate an expression form over in-scope `locals`. `log` is captured by
+   the runner. Await sites wrap all-warm (async …) sub-expressions so the
+   async arm never truly suspends. Numeric leaves keep arithmetic contexts
+   total; nil/string/keyword leaves exercise value plumbing elsewhere."
+  [^java.util.Random r locals depth]
+  (let [num-leaf (fn [] (if (and (seq locals) (zero? (rint r 3)))
+                          (pick r locals)
+                          (rint r 100)))
+        any-leaf (fn [] (pick r (concat [1 42 nil true "s" :k] locals)))
+        sub (fn [ls] (gen-expr r ls (dec depth)))
+        choice (if (zero? depth)
+                 (pick r [:leaf :leaf :leaf :effect])
+                 (pick r [:leaf :effect :await :await :let :if :do :loop
+                          :case :try :vec :map-lit :thread :when :cond-arrow]))]
+    (case choice
+      :leaf (any-leaf)
+      :effect `(do (swap! ~'log conj ~(rint r 1000)) ~(any-leaf))
+      :await `(await (async ~(sub locals)))
+      :let (let [sym (gensym "x")]
+             `(let [~sym ~(sub locals)]
+                ~(sub (conj locals sym))))
+      :if `(if ~(sub locals) ~(sub locals) ~(sub locals))
+      :do `(do ~(sub locals) ~(sub locals))
+      :loop (let [i (gensym "i") acc (gensym "acc") v (gensym "v")]
+              `(loop [~i ~(inc (rint r 3)) ~acc 0]
+                 (if (pos? ~i)
+                   (let [~v ~(sub (conj locals acc))]
+                     (recur (dec ~i) (+ ~acc ~i)))
+                   [~acc ~(sub locals)])))
+      :case `(case ~(rint r 3)
+               0 ~(sub locals)
+               (1 2) ~(sub locals)
+               ~(sub locals))
+      :try `(try
+              ~(if (zero? (rint r 3))
+                 `(do (swap! ~'log conj :pre-throw)
+                      (throw (ex-info "boom" {:i ~(rint r 10)}))
+                      ~(any-leaf))
+                 (sub locals))
+              (~'catch clojure.lang.ExceptionInfo e#
+                       [:caught ~(sub locals)]))
+      :vec [(sub locals) (sub locals)]
+      :map-lit {:a (sub locals) :b (sub locals)}
+      :thread `(-> ~(num-leaf) (+ ~(rint r 10)) (vector ~(sub locals)))
+      :when `(when ~(sub locals) ~(sub locals))
+      :cond-arrow `(cond-> ~(num-leaf)
+                     ~(sub locals) (+ 1)))))
+
+;; ---------------------------------------------------------------------------
+;; runners — both arms compiled per generated body via eval
+
+(defn- compile-sync [form]
+  (eval `(fn [~'log] (async+sync true ~form))))
+
+(defn- compile-async-all-warm [form]
+  ;; run the CPS arm and require synchronous completion (all awaits warm)
+  (eval `(fn [~'log]
+           (let [res# (volatile! ::none) err# (volatile! ::none)]
+             ((async ~form) #(vreset! res# %) #(vreset! err# %))
+             (when-not (= ::none @err#) (throw @err#))
+             (when (= ::none @res#)
+               (throw (ex-info "async arm did not complete synchronously all-warm"
+                               {:form '~form})))
+             @res#))))
+
+(defn- outcome [f]
+  (let [log (atom [])]
+    (try {:value (f log) :log @log}
+         (catch Throwable t
+           {:error (class t) :log @log}))))
+
+(deftest sync≡async-all-warm-generative
+  (let [r (java.util.Random. 42)]
+    (dotimes [i 300]
+      (let [form (gen-expr r [] 4)
+            s (outcome (compile-sync form))
+            a (outcome (compile-async-all-warm form))]
+        (is (= s a)
+            (str "case " i " diverged:\n" (pr-str form)
+                 "\nsync:  " (pr-str s)
+                 "\nasync: " (pr-str a)))))))
+
+(deftest exception-equality-generative
+  ;; bodies biased toward throwing: uncaught exceptions must reach the error
+  ;; continuation with the same class as the sync throw
+  (let [r (java.util.Random. 4242)]
+    (dotimes [i 100]
+      (let [form `(do ~(gen-expr r [] 3)
+                      (when (zero? ~(rint r 2))
+                        (throw (ex-info "unhandled" {})))
+                      ~(gen-expr r [] 2))
+            s (outcome (compile-sync form))
+            a (outcome (compile-async-all-warm form))]
+        (is (= s a)
+            (str "exception case " i " diverged:\n" (pr-str form)
+                 "\nsync:  " (pr-str s)
+                 "\nasync: " (pr-str a)))))))

--- a/test/is/simm/partial_cps/equivalence_test.clj
+++ b/test/is/simm/partial_cps/equivalence_test.clj
@@ -47,10 +47,17 @@
                    (let [~v ~(sub (conj locals acc))]
                      (recur (dec ~i) (+ ~acc ~i)))
                    [~acc ~(sub locals)])))
-      :case `(case ~(rint r 3)
-               0 ~(sub locals)
-               (1 2) ~(sub locals)
-               ~(sub locals))
+      :case (if (zero? (rint r 2))
+              ;; int dispatch and KEYWORD dispatch compile to different case*
+              ;; strategies (tableswitch vs hash) — cover both
+              `(case ~(rint r 3)
+                 0 ~(sub locals)
+                 (1 2) ~(sub locals)
+                 ~(sub locals))
+              `(case ~(pick r [:a :b :c :d])
+                 :a ~(sub locals)
+                 (:b :c) ~(sub locals)
+                 ~(sub locals)))
       :try `(try
               ~(if (zero? (rint r 3))
                  `(do (swap! ~'log conj :pre-throw)


### PR DESCRIPTION
Foundation for datahike's cljs async engine (PR D of the grounded workplan); generalizes the `async+sync` pattern that originated in konserve, with the two fixes it always needed.

## `async+sync` — one body, two modes

- **`:clj` emits only the stripped synchronous form** — no dead async arm in the bytecode, no runtime `if`, and `sync?` is not even evaluated. Shared cljc engine code costs the JVM nothing.
- **`:cljs` emits `(if sync? <stripped> (async body…))`** — runtime dispatch, amortized at call frequency.

## Hygienic strip (`ioc/strip-breakpoints`)

The konserve/PSS strips rewrite by **bare symbol name** — an aliased `pc/await` survives into the sync arm and throws at runtime, only when that branch executes. The new strip resolves through the **same machinery the async transform uses**: breakpoints matched on the original operator before macroexpansion (so `cljs.core/await` never expands), aliased/qualified awaits resolved via `var-name`, and nested `async`/`async+sync` via explicit **macro** resolution — necessary because cljs `resolve-var` guesses a current-ns name for macro-only symbols, so a var-first fallback never fires for them (the cljs test caught this; the clj arm passed). Quoted forms untouched; locals shadowing `await`/`async` are rejected at compile time; nested `async+sync` strips as same-mode.

## `async-expr?`

Async expressions remain plain 2-arity fns (`fn?` stays true — spindel's `(if (fn? x) (await x) x)` duck-typing keeps working unmigrated) and are now marked at creation (cljs property / clj metadata). Engines get a reliable discriminator between a fn-as-value and an async return — the enabler for user-supplied async functions in query clauses.

## `all`

Ordered gather over async exprs: each branch is driven to its first true suspension before the next launches (under an enclosing trampoline a branch *returns* its Thunk, and only one can propagate — so `all` drives each chain itself). All-warm inputs resolve synchronously before `all` returns, preserving the trampoline's sync-completion property; first error rejects; invoke-once; no cancellation (none exists in the runtime — documented).

## Tests

clj 162/237 green (5 new: sync-only emission incl. `sync?`-not-evaluated, aliased/qualified strip, threading-macro expansion parity, quote preservation, shadowing rejection, `all` semantics, marker). cljs suites green incl. **100k-warm-await depth stress** (constant stack at engine scale) and **10k-branch `all`**. Existing suites unaffected; konserve's own macro untouched (migration at its leisure).